### PR TITLE
Upgrade tiqr-core to snapshot-14

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,7 +82,7 @@ dependencies {
         }
     }
 
-    implementation("org.tiqr:core:0.0.33.13-SNAPSHOT")
+    implementation("org.tiqr:core:0.0.33.14-SNAPSHOT")
     implementation("org.tiqr:data:0.0.10.5-SNAPSHOT")
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.coroutines.core)


### PR DESCRIPTION
This update will cause the eduID app to close after completing authentication. When used to authenticate for a mobile app/website, it will return the user to the website when authentication is completed.